### PR TITLE
[TASK] Updated Composer requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,12 +9,10 @@
         "conversion"
     ],
     "require": {
-        "php": "~5.6.0|7.0.2|~7.0.6",
-        "magento/module-backend": "100.0.*|100.1.*|100.2.*|101.0.*|101.1.*",
-        "magento/framework": "100.0.*|100.1.*|100.2.*|101.0.*|101.1.*"
+        "php": "~5.6.5|7.0.2|7.0.4|~7.0.6|^7.1.0"
     },
     "type": "magento2-module",
-    "version": "2.0.8",
+    "version": "2.0.9",
     "license": [
         "OSL-3.0",
         "AFL-3.0"


### PR DESCRIPTION
Packages `magento/module-backend` and `magento/framework1 don’t exist anymore.
It also allows more PHP versions.

Tested PHP 7.3