### PR TITLE
[BUGFIX] Solved issue with single quotation marks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "php": "~5.6.5|7.0.2|7.0.4|~7.0.6|^7.1.0"
     },
     "type": "magento2-module",
-    "version": "2.0.9",
+    "version": "2.0.10",
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/view/frontend/templates/cfy_data.phtml
+++ b/view/frontend/templates/cfy_data.phtml
@@ -7,7 +7,7 @@
 <script type="text/javascript">
     Conversify = window.Conversify || [];
     try {
-        _cfy_data = JSON.parse('<?php echo json_encode($block->getModelData()); ?>');
+        _cfy_data = JSON.parse(atob('<?php echo base64_encode(json_encode($block->getModelData())); ?>'));
         for (k in _cfy_data) {
             console.log(k);
             if (k == 'conversion') {


### PR DESCRIPTION
If a product had a single quotation mark (`'`) in the name, the JavaScript crashed because of invalid data.

Example:
```
_cfy_data = JSON.parse('{"pagetype":"shoppingcart","cart":{"grand_total":"13.9500","logged_in":false,"contents":[{"name":"2016 Villa Sant'Anna Rosso di Montepulciano DOC","sku":"VILL-16201","qty":1,"id":"113","price":"11.5300","row":"11.5300","row_tax":"13.9500"}]}}');
```
In here `Sant'Anna` has a single quotation mark, therefore `JSON.parse` ends before the actual end of the JSON string.